### PR TITLE
Handle settings better

### DIFF
--- a/RustLanguageExtension/OptionsModel.cs
+++ b/RustLanguageExtension/OptionsModel.cs
@@ -36,7 +36,7 @@ namespace RustLanguageExtension
         public static void LoadData()
         {
             var settingsManager = new ShellSettingsManager(ServiceProvider.GlobalProvider);
-            var userSettingsStore = settingsManager.GetWritableSettingsStore(Microsoft.VisualStudio.Settings.SettingsScope.UserSettings);
+            var userSettingsStore = settingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
             EnsureSettingsStore(userSettingsStore);
 
             toolchain = userSettingsStore.GetString(SettingsCollection, ToolchainProperty);
@@ -45,7 +45,7 @@ namespace RustLanguageExtension
         public static void SaveData()
         {
             var settingsManager = new ShellSettingsManager(ServiceProvider.GlobalProvider);
-            var userSettingsStore = settingsManager.GetWritableSettingsStore(Microsoft.VisualStudio.Settings.SettingsScope.UserSettings);
+            var userSettingsStore = settingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
             EnsureSettingsStore(userSettingsStore);
 
             userSettingsStore.SetString(SettingsCollection, ToolchainProperty, toolchain);

--- a/RustLanguageExtension/OptionsModel.cs
+++ b/RustLanguageExtension/OptionsModel.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.VisualStudio.Settings;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Settings;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RustLanguageExtension
+{
+    internal class OptionsModel
+    {
+        private const string SettingsCollection = "RustLanguageExtension";
+        private const string ToolchainDefault = "nightly";
+        private const string ToolchainProperty = "Toolchain";
+
+        private static string toolchain;
+        public static string Toolchain
+        {
+            get
+            {
+                if (toolchain == null)
+                {
+                    LoadData();
+                }
+
+                return toolchain;
+            }
+            set
+            {
+                toolchain = value;
+            }
+        }
+
+        public static void LoadData()
+        {
+            var settingsManager = new ShellSettingsManager(ServiceProvider.GlobalProvider);
+            var userSettingsStore = settingsManager.GetWritableSettingsStore(Microsoft.VisualStudio.Settings.SettingsScope.UserSettings);
+            EnsureSettingsStore(userSettingsStore);
+
+            toolchain = userSettingsStore.GetString(SettingsCollection, ToolchainProperty);
+        }
+
+        public static void SaveData()
+        {
+            var settingsManager = new ShellSettingsManager(ServiceProvider.GlobalProvider);
+            var userSettingsStore = settingsManager.GetWritableSettingsStore(Microsoft.VisualStudio.Settings.SettingsScope.UserSettings);
+            EnsureSettingsStore(userSettingsStore);
+
+            userSettingsStore.SetString(SettingsCollection, ToolchainProperty, toolchain);
+        }
+
+        private static void EnsureSettingsStore(WritableSettingsStore settingsStore)
+        {
+            if (!settingsStore.CollectionExists(SettingsCollection))
+            {
+                settingsStore.CreateCollection(SettingsCollection);
+            }
+
+            if (!settingsStore.PropertyExists(SettingsCollection, ToolchainProperty))
+            {
+                settingsStore.SetString(SettingsCollection, ToolchainProperty, ToolchainDefault);
+            }
+        }
+    }
+}

--- a/RustLanguageExtension/OptionsPage.cs
+++ b/RustLanguageExtension/OptionsPage.cs
@@ -10,14 +10,22 @@ namespace RustLanguageExtension
 {
     class OptionsPage: DialogPage
     {
-        private string toolchain = "nightly";
-
         [DisplayName("Toolchain to Use")]
         [Description("Toolchain to use when invoking the Rust Language Server")]
         public string Toolchain
         {
-            get { return toolchain; }
-            set { toolchain = value; }
+            get { return OptionsModel.Toolchain; }
+            set { OptionsModel.Toolchain = value; }
+        }
+
+        public override void LoadSettingsFromStorage()
+        {
+            OptionsModel.LoadData();
+        }
+
+        public override void SaveSettingsToStorage()
+        {
+            OptionsModel.SaveData();
         }
     }
 }

--- a/RustLanguageExtension/RustLanguageExtension.cs
+++ b/RustLanguageExtension/RustLanguageExtension.cs
@@ -54,13 +54,7 @@ namespace RustLanguageExtension
 
         public async System.Threading.Tasks.Task OnLoadedAsync()
         {
-            // Since the extension is loaded via MEF the package with options is not guarenteed to be loaded yet.
-            // Load the package here so that options can be accessed.
-            IVsShell shell = await ServiceProvider.GetGlobalServiceAsync(typeof(SVsShell)) as IVsShell;
-            Guid PackageToBeLoadedGuid = new Guid(RustLanguageExtensionOptionsPackage.PackageGuidString);
-            shell.LoadPackage(ref PackageToBeLoadedGuid, out var package);
-
-            var toolchain = RustLanguageExtensionOptionsPackage.Instance.OptionToolchain;
+            var toolchain = OptionsModel.Toolchain;
             if (!await Rustup.HasToolchain(toolchain))
             {
                 await VsUtilities.ShowInfoBar($"configured toolchain {toolchain} is not installed, please install and relaunch VS");

--- a/RustLanguageExtension/RustLanguageExtension.cs
+++ b/RustLanguageExtension/RustLanguageExtension.cs
@@ -31,7 +31,7 @@ namespace RustLanguageExtension
 
         public async Task<Connection> ActivateAsync(CancellationToken token)
         {
-            var toolchain = RustLanguageExtensionOptionsPackage.Instance.OptionToolchain;
+            var toolchain = OptionsModel.Toolchain;
             var env = await MakeEnvironment(toolchain);
             var startInfo = new ProcessStartInfo()
             {

--- a/RustLanguageExtension/RustLanguageExtension.csproj
+++ b/RustLanguageExtension/RustLanguageExtension.csproj
@@ -57,6 +57,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="OptionsModel.cs" />
     <Compile Include="OptionsPage.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/RustLanguageExtension/RustLanguageExtensionOptionsPackage.cs
+++ b/RustLanguageExtension/RustLanguageExtensionOptionsPackage.cs
@@ -60,23 +60,7 @@ namespace RustLanguageExtension
         /// </summary>
         protected override void Initialize()
         {
-            Instance = this;
             base.Initialize();
-        }
-
-        public static RustLanguageExtensionOptionsPackage Instance
-        {
-            get;
-            private set;
-        }
-
-        public string OptionToolchain
-        {
-            get
-            {
-                OptionsPage page = (OptionsPage)GetDialogPage(typeof(OptionsPage));
-                return page.Toolchain;
-            }
         }
 
         #endregion


### PR DESCRIPTION
Settings should be decoupled from the UI logic. From what I have learned, the page [here](https://docs.microsoft.com/en-us/visualstudio/extensibility/creating-an-options-page) is hopelessly out of date and not representative of today's best practices.

This change also makes it so that it is no longer necessary to load the package before reading settings. Loading the package was a hack and is discouraged in almost all situations.