### PR TITLE
Appveyor dll fix

### DIFF
--- a/RustLanguageExtension/RustLanguageExtension.csproj
+++ b/RustLanguageExtension/RustLanguageExtension.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.5.100\build\Microsoft.VSSDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.5.100\build\Microsoft.VSSDK.BuildTools.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
@@ -17,7 +18,6 @@
   <PropertyGroup>
     <StartupObject />
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ image: Visual Studio 2017
 
 build_script:
   - nuget restore
-  - msbuild .\RustLanguageExtension\RustLanguageExtension.csproj /p:configuration=Release /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /v:diag
+  - msbuild .\RustLanguageExtension\RustLanguageExtension.csproj /p:configuration=Release /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /v:m
 
 artifacts:
   - path: '**\*.vsix'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2017
 
 build_script:
-  - nuget restore
+  - nuget restore -Verbosity quiet
   - msbuild .\RustLanguageExtension\RustLanguageExtension.csproj /p:configuration=Release /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /v:m
 
 artifacts:

--- a/build.out
+++ b/build.out
@@ -1,0 +1,910 @@
+Microsoft (R) Build Engine version 4.7.2556.0
+[Microsoft .NET Framework, version 4.0.30319.42000]
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe /p:ZipPackageCompressionLevel=normal /v:diag .\RustLanguageExtension\RustLanguageExtension.csproj
+Build started 12/8/2017 3:10:49 PM.
+Environment at start of build:
+ALLUSERSPROFILE = C:\ProgramData
+APPDATA = C:\Users\dagriffe\AppData\Roaming
+CommonProgramFiles = C:\Program Files (x86)\Common Files
+CommonProgramFiles(x86) = C:\Program Files (x86)\Common Files
+CommonProgramW6432 = C:\Program Files\Common Files
+COMPUTERNAME = DAGRIFFE-WORK
+ComSpec = C:\WINDOWS\system32\cmd.exe
+FSHARPINSTALLDIR = C:\Program Files (x86)\Microsoft SDKs\F#\4.1\Framework\v4.0\
+HOMEDRIVE = C:
+HOMEPATH = \Users\dagriffe
+JAVA_HOME = C:\Program Files\Java\jre1.8.0_152\bin
+JDK_HOME = C:\Program Files\Java\jdk1.8.0_152
+LOCALAPPDATA = C:\Users\dagriffe\AppData\Local
+LOGONSERVER = \\CY1-RED-DC-17
+MSBuildLoadMicrosoftTargetsReadOnly = true
+MSBUILDLOGTASKINPUTS = 1
+NugetMachineInstallRoot = E:\NugetCache
+NUMBER_OF_PROCESSORS = 8
+OneDrive = C:\Users\dagriffe\OneDrive
+OS = Windows_NT
+Path = C:\ProgramData\Oracle\Java\javapath;C:\Program Files\Common Files\Microsoft Shared\Microsoft Online Services;C:\Program Files (x86)\Common Files\Microsoft Shared\Microsoft Online Services;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\Program Files\Microsoft SQL Server\130\Tools\Binn\;C:\Program Files\dotnet\;C:\Program Files (x86)\nodejs\;C:\Program Files\Git\cmd;C:\Users\dagriffe\.dnx\bin;C:\Program Files\Microsoft DNX\Dnvm\;C:\Program Files\Microsoft SQL Server\120\Tools\Binn\;C:\Program Files\PuTTY\;C:\Users\dagriffe\.cargo\bin;C:\Users\dagriffe\AppData\Local\Microsoft\WindowsApps;C:\Users\dagriffe\AppData\Roaming\npm;C:\Program Files\Microsoft VS Code\bin;C:\Users\dagriffe\Downloads\CredentialProviderBundle;C:\Program Files\Java\jdk1.8.0_152;C:\Program Files\Java\jre1.8.0_152\bin;
+PATHEXT = .COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC
+PROCESSOR_ARCHITECTURE = x86
+PROCESSOR_ARCHITEW6432 = AMD64
+PROCESSOR_IDENTIFIER = Intel64 Family 6 Model 94 Stepping 3, GenuineIntel
+PROCESSOR_LEVEL = 6
+PROCESSOR_REVISION = 5e03
+ProgramData = C:\ProgramData
+ProgramFiles = C:\Program Files (x86)
+ProgramFiles(x86) = C:\Program Files (x86)
+ProgramW6432 = C:\Program Files
+PROMPT = $P$G
+PSModulePath = C:\Users\dagriffe\Documents\WindowsPowerShell\Modules
+PUBLIC = C:\Users\Public
+SESSIONNAME = Console
+SystemDrive = C:
+SystemRoot = C:\WINDOWS
+TEMP = C:\Users\dagriffe\AppData\Local\Temp
+TMP = C:\Users\dagriffe\AppData\Local\Temp
+ToastSettings = {"collection":[{"SolutionName":"Outlook Not Responding","SolutionStatus":true,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Outlook Multiple Process running","SolutionStatus":true,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Draft Email Protection","SolutionStatus":true,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Pending Reboot","SolutionStatus":false,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Password Reset","SolutionStatus":true,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"IE Recommended Settings","SolutionStatus":false,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Smart Card certificate is going to expire soon","SolutionStatus":false,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Smart Card has expired or multiple certificates","SolutionStatus":false,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Unable to connect to wireless LAN","SolutionStatus":true,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Wireless driver update","SolutionStatus":true,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Record Skype for Business experience","SolutionStatus":false,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Delete duplicate Outlook .ost file(s) to recover disk space","SolutionStatus":true,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"DirectAccess cannot connect","SolutionStatus":false,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Outlook Multiple Processes running","SolutionStatus":true,"ChangedBy":"TM.Initialization"},{"SolutionName":"Direct Access cannot connect","SolutionStatus":false,"ChangedBy":"TM.Initialization"}]}
+UATDATA = C:\windows\CCM\UATData\D9F8C395-CAB8-491d-B8AC-179A1FE1BE77
+USERDNSDOMAIN = REDMOND.CORP.MICROSOFT.COM
+USERDOMAIN = REDMOND
+USERDOMAIN_ROAMINGPROFILE = REDMOND
+USERNAME = dagriffe
+USERPROFILE = C:\Users\dagriffe
+VS140COMNTOOLS = C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\
+VSSDK140Install = C:\Program Files (x86)\Microsoft Visual Studio 14.0\VSSDK\
+windir = C:\WINDOWS
+
+Overriding target "GetFrameworkPaths" in project "C:\Windows\Microsoft.NET\Framework\v4.0.30319\Microsoft.Common.targets" with target "GetFrameworkPaths" from project "C:\Windows\Microsoft.NET\Framework\v4.0.30319\Microsoft.NETFramework.targets".
+Overriding target "SatelliteDllsProjectOutputGroup" in project "C:\Windows\Microsoft.NET\Framework\v4.0.30319\Microsoft.Common.targets" with target "SatelliteDllsProjectOutputGroup" from project "C:\Windows\Microsoft.NET\Framework\v4.0.30319\Microsoft.WinFX.targets".
+The target "FindReferenceAssembliesForReferences" listed in a BeforeTargets attribute at "C:\Users\dagriffe\Documents\rls-vs2017\packages\Microsoft.VisualStudio.SDK.EmbedInteropTypes.15.0.12\build\Microsoft.VisualStudio.SDK.EmbedInteropTypes.targets (6,81)" does not exist in the project, and will be ignored.
+Project "C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\RustLanguageExtension.csproj" on node 1 (default targets).
+Initial Properties:
+__internal_VSCTDefinitions = __CTC__;_CTC_GUIDS_;
+_AfterCompileWinFXInternalDependsOn = 
+        PrepareResourcesForSatelliteAssemblies;
+        MergeLocalizationDirectives;
+        AfterCompileWinFX
+    
+_CompileTargetNameForLocalType = _CompileTemporaryAssembly
+_DebugSymbolsProduced = true
+_DeploymentApplicationManifestIdentity = Native.RustLanguageExtension
+_DeploymentBuiltUpdateInterval = 0
+_DeploymentBuiltUpdateIntervalUnits = Days
+_DeploymentDeployManifestIdentity = RustLanguageExtension.application
+_DeploymentFileMappingExtension = 
+_DeploymentTargetApplicationManifestFileName = Native.RustLanguageExtension.manifest
+_DeploymentUrl = 
+_DocumentationFileProduced = false
+_GetChildProjectCopyToOutputDirectoryItems = true
+_OriginalConfiguration = Release
+_OriginalPlatform = AnyCPU
+_ProjectDefaultTargets = Build
+_RequireMCPass2ForMainAssembly = false
+_RequireMCPass2ForSatelliteAssemblyOnly = false
+_ResolveReferenceDependencies = false
+_ResourceNameInMainAssembly = RustLanguageExtension.g.resources
+_SGenDllCreated = false
+_SGenDllName = RustLanguageExtension.XmlSerializers.dll
+_SGenGenerateSerializationAssembliesConfig = Auto
+AddAdditionalExplicitAssemblyReferences = true
+AdditionalExplicitAssemblyReferences = System.Core;
+AllowedReferenceAssemblyFileExtensions = 
+      .winmd;
+      .dll;
+      .exe
+    
+AllowedReferenceRelatedFileExtensions = 
+      .pdb;
+      .xml;
+      .pri
+    
+ALLUSERSPROFILE = C:\ProgramData
+AlwaysCompileMarkupFilesInSeparateDomain = true
+APPDATA = C:\Users\dagriffe\AppData\Roaming
+AppDesignerFolder = Properties
+AreDependenciesSetOnPackage = false
+AssemblyFoldersSuffix = AssemblyFoldersEx
+AssemblyName = RustLanguageExtension
+AssemblyOriginatorKeyFile = Key.snk
+AssemblySearchPaths = 
+      {CandidateAssemblyFiles};
+      ;
+      {HintPathFromItem};
+      {TargetFrameworkDirectory};
+      {Registry:Software\Microsoft\.NETFramework,v4.6.1,AssemblyFoldersEx};
+      {AssemblyFolders};
+      {GAC};
+      {RawFileName};
+      bin\Release\
+    
+AssignTargetPathsDependsOn = 
+AutoUnifyAssemblyReferences = true
+AvailablePlatforms = Any CPU,x86,x64
+BaseIntermediateOutputPath = obj\
+BuildCompileAction = Build
+BuildDependsOn = VerifyTargetVersion;
+      EntityDeploy;
+      
+      BeforeBuild;
+      CoreBuild;
+      AfterBuild
+    
+    
+BuildGenerateSourcesAction = Build
+BuildingProject = false
+BuildInParallel = true
+BuildLinkAction = Build
+BuildProjectReferences = true
+BuildSystem = MSBuild
+BuildTaskAssembly = PresentationBuildTasks, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
+BuiltProjectOutputGroupDependsOn = PrepareForBuild
+BypassVsixValidation = false
+CleanDependsOn = 
+      
+      BeforeClean;
+      UnmanagedUnregistration;
+      CoreClean;
+      CleanReferencedProjects;
+      CleanPublishFolder;
+      AfterClean
+    ;
+      EntityClean;
+    
+CleanFile = RustLanguageExtension.csproj.FileListAbsolute.txt
+CodeAnalysisTargets = C:\Program Files (x86)\MSBuild\Microsoft\VisualStudio\v11.0\CodeAnalysis\Microsoft.CodeAnalysis.targets
+CommonProgramFiles = C:\Program Files (x86)\Common Files
+CommonProgramW6432 = C:\Program Files\Common Files
+CompileDependsOn = 
+        
+      ResolveReferences;
+      ResolveKeySource;
+      SetWin32ManifestProperties;
+      _GenerateCompileInputs;
+      BeforeCompile;
+      _TimeStampBeforeCompile;
+      CoreCompile;
+      _TimeStampAfterCompile;
+      AfterCompile;
+    ;
+        _AfterCompileWinFXInternal
+    
+CompileLicxFilesDependsOn = 
+CompileTargetNameForTemporaryAssembly = CompileTemporaryAssembly
+ComputeIntermediateSatelliteAssembliesDependsOn = 
+      CreateManifestResourceNames
+    
+COMPUTERNAME = DAGRIFFE-WORK
+ComReferenceExecuteAsTool = false
+ComReferenceNoClassMembers = false
+ComSpec = C:\WINDOWS\system32\cmd.exe
+configuration = Release
+ConfigurationName = Release
+ConsiderPlatformAsProcessorArchitecture = true
+ContentFilesProjectOutputGroupDependsOn = PrepareForBuild;AssignTargetPaths
+ContinueOnError = false
+CopyBuildOutputToOutputDirectory = true
+CopyOutputSymbolsToOutputDirectory = false
+CopyPkgDefDependsOn = ;GeneratePkgDef;CheckCTOFileHasChanged
+CopyVsixExtensionFiles = false
+CopyVsixExtensionFilesDependsOn = ;GetVsixSourceItems
+CopyVsixManifestFileDependsOn = ;DetokenizeVsixManifestFile
+CopyVsixManifestToOutput = true
+CopyZipOutputToOutputDirectory = true
+CoreBuildDependsOn = 
+      BuildOnlySettings;
+      PrepareForBuild;
+      PreBuildEvent;
+      ResolveReferences;
+      PrepareResources;
+      ResolveKeySource;
+      Compile;
+      ExportWindowsMDFile;
+      UnmanagedUnregistration;
+      GenerateSerializationAssemblies;
+      CreateSatelliteAssemblies;
+      GenerateManifests;
+      GetTargetPath;
+      PrepareForRun;
+      UnmanagedRegistration;
+      IncrementalClean;
+      PostBuildEvent
+    
+CoreCleanDependsOn = 
+CoreCompileDependsOn = _ComputeNonExistentFileProperty
+CoreResGenDependsOn = 
+CreateCustomManifestResourceNamesDependsOn = 
+CreateHardLinksForCopyAdditionalFilesIfPossible = false
+CreateManifestResourceNamesDependsOn = 
+CreatePkgDefAssemblyToProcess = C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\bin\Release\RustLanguageExtension.dll
+CreateSatelliteAssembliesDependsOn = 
+      _GenerateSatelliteAssemblyInputs;
+      ComputeIntermediateSatelliteAssemblies;
+      GenerateSatelliteAssemblies
+    
+CreateVsixContainer = true
+CreateVsixContainerDependsOn = ;ValidateVsixParts;GenerateTemplatesManifest
+CustomAfterMicrosoftCommonTargets = C:\Program Files (x86)\MSBuild\v4.0\Custom.After.Microsoft.Common.targets
+CustomAfterMicrosoftCSharpTargets = C:\Program Files (x86)\MSBuild\v4.0\Custom.After.Microsoft.CSharp.targets
+CustomBeforeMicrosoftCommonTargets = C:\Program Files (x86)\MSBuild\v4.0\Custom.Before.Microsoft.Common.targets
+CustomBeforeMicrosoftCSharpTargets = C:\Program Files (x86)\MSBuild\v4.0\Custom.Before.Microsoft.CSharp.targets
+DebugSymbolsProjectOutputGroupDependsOn = 
+DebugType = pdbonly
+DefaultLanguageSourceExtension = .cs
+DeferredValidationErrorsFileName = obj\Release\\AC2C1ABA-CCF6-44D4-8127-588FD4D0A860-DeferredValidationErrors.xml
+DefineConstants = TRACE
+DelaySign = 
+DeployExtension = false
+DeploymentType = Installed
+DeployVsixExtensionFilesDependsOn = ;Compile;GetVsixDeploymentPath;FindExistingDeploymentPath;GetVsixSourceItems
+DeployVSTemplates = true
+DesignTimeIntermediateOutputPath = obj\Release\InProcessTempFiles\
+DesignTimeResolveAssemblyReferencesDependsOn = 
+      GetFrameworkPaths;
+      GetReferenceAssemblyPaths;
+      ResolveReferences
+    
+DetokenizeVsixManifestFileDependsOn = ;AssignProjectConfiguration;FindSourceVsixManifest
+DevEnvDir = *Undefined*
+DocumentationProjectOutputGroupDependsOn = 
+EmbeddedWin32Manifest = 
+EntityDeployDependsOn = 
+EntityDeployIntermediateResourcePath = obj\Release\edmxResourcesToEmbed\
+ErrorReport = prompt
+ExpandSDKAllowedReferenceExtensions = 
+      .winmd;
+      .dll
+    
+ExpandSDKReferencesDependsOn = 
+      ResolveSDKReferences
+    
+FindExistingDeploymentPathDependsOn = ;GetVsixDeploymentPath
+Framework20Dir = @(_TargetFramework20DirectoryItem)
+Framework30Dir = @(_TargetFramework30DirectoryItem)
+Framework35Dir = @(_TargetFramework35DirectoryItem)
+Framework40Dir = @(_TargetFramework40DirectoryItem)
+FrameworkDir = @(_TargetFramework40DirectoryItem)
+FrameworkPathOverride = C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1
+FrameworkRegistryBase = Software\Microsoft\.NETFramework
+FrameworkSDKDir = @(_TargetFrameworkSDKDirectoryItem)
+FrameworkSDKRoot = 
+FSHARPINSTALLDIR = C:\Program Files (x86)\Microsoft SDKs\F#\4.1\Framework\v4.0\
+FullReferenceAssemblyNames = Full
+GenerateCompiledExpressionsTempFilePathForEditing = obj\Release\\TemporaryGeneratedFile_E7A71F73-0F8D-4B9B-B56E-8E70B10BC5D3.cs
+GenerateCompiledExpressionsTempFilePathForTypeInfer = obj\Release\\TemporaryGeneratedFile_5937a670-0e60-4077-877b-f7221da3dda1.cs
+GenerateCompiledExpressionsTempFilePathForValidation = obj\Release\\TemporaryGeneratedFile_036C0B5B-1481-4323-8D20-8F5ADCB23D92.cs
+GeneratedFileExtension = .g.cs
+GenerateManifestsDependsOn = 
+      SetWin32ManifestProperties;
+      GenerateApplicationManifest;
+      GenerateDeploymentManifest
+    
+GeneratePkgDefDependsOn = ;Compile
+GeneratePkgDefFile = true
+GenerateTargetFrameworkAttribute = true
+GenerateTemplatesManifestDependsOn = ;ValidateVsixParts
+GetCopyToOutputDirectoryItemsDependsOn = 
+      AssignTargetPaths;
+      _SplitProjectReferencesByFileExistence
+    
+GetFrameworkPathsDependsOn = 
+GetReferenceAssemblyPathsDependsOn = 
+        ;
+        GetWinFXPath
+    
+GetTargetPathDependsOn = 
+GetVsixDeploymentPathDependsOn = ;DetokenizeVsixManifestFile
+GetVsixItemsToBundleDependsOn = ;Compile
+GetVsixSourceItemsDependsOn = ;AssignProjectConfiguration;DetokenizeVsixManifestFile;ZipProjects;ZipItems
+HighEntropyVA = true
+HOMEDRIVE = C:
+HOMEPATH = \Users\dagriffe
+HostInBrowser = false
+ImplicitlyExpandDesignTimeFacades = true
+ImplicitlyExpandDesignTimeFacadesDependsOn = 
+      ;
+      GetReferenceAssemblyPaths
+    
+ImportByWildcardAfterMicrosoftCommonTargets = true
+ImportByWildcardAfterMicrosoftCSharpTargets = true
+ImportByWildcardAfterMicrosoftNetFrameworkProps = true
+ImportByWildcardAfterMicrosoftNetFrameworkTargets = true
+ImportByWildcardBeforeMicrosoftCommonTargets = true
+ImportByWildcardBeforeMicrosoftCSharpTargets = true
+ImportByWildcardBeforeMicrosoftNetFrameworkProps = true
+ImportByWildcardBeforeMicrosoftNetFrameworkTargets = true
+ImportUserLocationsByWildcardAfterMicrosoftCommonTargets = true
+ImportUserLocationsByWildcardAfterMicrosoftCSharpTargets = true
+ImportUserLocationsByWildcardAfterMicrosoftNetFrameworkProps = true
+ImportUserLocationsByWildcardAfterMicrosoftNetFrameworkTargets = true
+ImportUserLocationsByWildcardBeforeMicrosoftCommonTargets = true
+ImportUserLocationsByWildcardBeforeMicrosoftCSharpTargets = true
+ImportUserLocationsByWildcardBeforeMicrosoftNetFrameworkProps = true
+ImportUserLocationsByWildcardBeforeMicrosoftNetFrameworkTargets = true
+IncludeAddModulesInVSIXContainer = true
+IncludeAssemblyInVSIXContainer = true
+IncludeCOMReferencesInVSIXContainer = true
+IncludeCopyLocalReferencesInVSIXContainer = true
+IncludeDebugSymbolsInLocalVSIXDeployment = false
+IncludeDebugSymbolsInVSIXContainer = false
+IncludeDocFilesInVSIXContainer = false
+IncludePkgdefInVSIXContainer = true
+IncludeSatelliteAssembliesInVSIXContainer = true
+IncludeSGenDllInVSIXContainer = true
+IntermediateOutputPath = obj\Release\
+IntermediateVsixManifest = obj\Release\extension.vsixmanifest
+IsLibrary = true
+IsProductComponent = false
+JAVA_HOME = C:\Program Files\Java\jre1.8.0_152\bin
+JDK_HOME = C:\Program Files\Java\jdk1.8.0_152
+Language = C#
+LoadTimeSensitiveProperties = 
+      ;
+    
+LoadTimeSensitiveTargets = 
+      ;
+      XamlMarkupCompilePass1;
+    
+LOCALAPPDATA = C:\Users\dagriffe\AppData\Local
+LocalizationDirectivesToLocFile = None
+LOGONSERVER = \\CY1-RED-DC-17
+MarkupCompilePass2ForMainAssemblyDependsOn = 
+                     GenerateTemporaryTargetAssembly;
+                     MarkupCompilePass2;
+                     AfterMarkupCompilePass2;
+                     CleanupTemporaryTargetAssembly
+       
+MaxTargetPath = 100
+MergeCtoResourceDependsOn = ;GenerateListOfCTO;VSCTCompile;CheckCTOFileHasChanged;GenerateResourceToMergeWithCTO
+MinimumVisualStudioVersion = 15.0
+MsAppxPackageTargets = C:\Program Files (x86)\MSBuild\Microsoft\VisualStudio\v11.0\AppxPackage\Microsoft.AppXPackage.Targets
+MSBuildAllProjects = ;C:\Windows\Microsoft.NET\Framework\v4.0.30319\Microsoft.CSharp.targets;C:\Windows\Microsoft.NET\Framework\v4.0.30319\Microsoft.NETFramework.props;C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\RustLanguageExtension.csproj;C:\Windows\Microsoft.NET\Framework\v4.0.30319\Microsoft.Common.targets;C:\Windows\Microsoft.NET\Framework\v4.0.30319\Microsoft.NETFramework.targets;C:\Windows\Microsoft.NET\Framework\v4.0.30319\Microsoft.Xaml.targets
+MSBuildBinPath = C:\Windows\Microsoft.NET\Framework\v4.0.30319
+MSBuildExtensionsPath = C:\Program Files (x86)\MSBuild
+MSBuildExtensionsPath32 = C:\Program Files (x86)\MSBuild
+MSBuildExtensionsPath64 = C:\Program Files\MSBuild
+MSBuildLoadMicrosoftTargetsReadOnly = true
+MSBUILDLOGTASKINPUTS = 1
+MSBuildNodeCount = 1
+MSBuildProgramFiles32 = C:\Program Files (x86)
+MSBuildProjectDefaultTargets = Build
+MSBuildProjectDirectory = C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension
+MSBuildProjectDirectoryNoRoot = Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension
+MSBuildProjectExtension = .csproj
+MSBuildProjectFile = RustLanguageExtension.csproj
+MSBuildProjectFullPath = C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\RustLanguageExtension.csproj
+MSBuildProjectName = RustLanguageExtension
+MSBuildRuntimeVersion = 4.0.30319
+MSBuildStartupDirectory = C:\Users\dagriffe\Documents\rls-vs2017
+MSBuildToolsPath = C:\Windows\Microsoft.NET\Framework\v4.0.30319
+MSBuildToolsPath32 = C:\Windows\Microsoft.NET\Framework\v4.0.30319\
+MSBuildToolsRoot = C:\Windows\Microsoft.NET\Framework\
+MSBuildToolsVersion = 4.0
+MSBuildUserExtensionsPath = C:\Users\dagriffe\AppData\Local\Microsoft\MSBuild
+MsTestToolsTargets = C:\Program Files (x86)\MSBuild\Microsoft\VisualStudio\v11.0\TeamTest\Microsoft.TeamTest.targets
+NoCompilerStandardLib = true
+NugetMachineInstallRoot = E:\NugetCache
+NuGetPackageImportStamp = 
+NUMBER_OF_PROCESSORS = 8
+OneDrive = C:\Users\dagriffe\OneDrive
+Optimize = true
+OS = Windows_NT
+OSVersion = 5.1.2600.0
+OutDir = bin\Release\
+OutputPath = bin\Release\
+OutputType = Library
+OverwriteReadOnlyFiles = false
+Path = C:\ProgramData\Oracle\Java\javapath;C:\Program Files\Common Files\Microsoft Shared\Microsoft Online Services;C:\Program Files (x86)\Common Files\Microsoft Shared\Microsoft Online Services;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\Program Files\Microsoft SQL Server\130\Tools\Binn\;C:\Program Files\dotnet\;C:\Program Files (x86)\nodejs\;C:\Program Files\Git\cmd;C:\Users\dagriffe\.dnx\bin;C:\Program Files\Microsoft DNX\Dnvm\;C:\Program Files\Microsoft SQL Server\120\Tools\Binn\;C:\Program Files\PuTTY\;C:\Users\dagriffe\.cargo\bin;C:\Users\dagriffe\AppData\Local\Microsoft\WindowsApps;C:\Users\dagriffe\AppData\Roaming\npm;C:\Program Files\Microsoft VS Code\bin;C:\Users\dagriffe\Downloads\CredentialProviderBundle;C:\Program Files\Java\jdk1.8.0_152;C:\Program Files\Java\jre1.8.0_152\bin;
+PATHEXT = .COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC
+Platform = AnyCPU
+PlatformName = AnyCPU
+PlatformTargetAsMSBuildArchitecture = CurrentArchitecture
+PlatformTargetAsMSBuildArchitectureExplicitlySet = false
+PostBuildEventDependsOn = 
+PreBuildEventDependsOn = 
+Prefer32Bit = false
+PrepareForBuildDependsOn = 
+      GetFrameworkPaths;GetReferenceAssemblyPaths;
+      RunRegRiched
+    
+PrepareForRunDependsOn = 
+      ZipProjects;
+      ZipItems;
+      
+      
+      CopyFilesToOutputDirectory
+    ;
+      GeneratePkgDef;
+      CopyPkgDef;
+      CreateVsixContainer;
+      DeployVsixExtensionFiles;
+      CopyVsixManifestFile;
+      CopyVsixExtensionFiles;
+    
+    
+PrepareResourceNamesDependsOn = 
+                    AssignWinFXEmbeddedResource;
+                    
+      AssignTargetPaths;
+      SplitResourcesByCulture;
+      CreateManifestResourceNames;
+      CreateCustomManifestResourceNames
+    
+      
+PrepareResourcesDependsOn = 
+      ValidationExtension;
+      ExpressionBuildExtension;
+      
+      XamlMarkupCompilePass1;
+      XamlMarkupCompilePass2;
+      
+                MarkupCompilePass1;
+                AfterMarkupCompilePass1;
+                MarkupCompilePass2ForMainAssembly;
+                FileClassification;
+                MainResourcesGeneration;
+                
+      PrepareResourceNames;
+      ResGen;
+      CompileLicxFiles
+    
+       
+    
+    ;MergeCtoResource
+PROCESSOR_ARCHITECTURE = x86
+PROCESSOR_ARCHITEW6432 = AMD64
+PROCESSOR_IDENTIFIER = Intel64 Family 6 Model 94 Stepping 3, GenuineIntel
+PROCESSOR_LEVEL = 6
+PROCESSOR_REVISION = 5e03
+ProcessorArchitecture = msil
+ProcessorArchitectureAsPlatform = AnyCPU
+ProgramData = C:\ProgramData
+ProgramFiles = C:\Program Files (x86)
+ProgramW6432 = C:\Program Files
+ProjectDesignTimeAssemblyResolutionSearchPaths = 
+      {CandidateAssemblyFiles};
+      ;
+      {HintPathFromItem};
+      {TargetFrameworkDirectory};
+      {Registry:Software\Microsoft\.NETFramework,v4.6.1,AssemblyFoldersEx};
+      {RawFileName};
+      C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\bin\Release\
+    
+ProjectDir = C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\
+ProjectExt = .csproj
+ProjectFileName = RustLanguageExtension.csproj
+ProjectFlavor = Client
+ProjectGuid = {9C4BA994-D4A5-407E-B57C-66E5923D0CA7}
+ProjectName = RustLanguageExtension
+ProjectPath = C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\RustLanguageExtension.csproj
+ProjectTypeGuids = {82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}
+PROMPT = $P$G
+PSModulePath = C:\Users\dagriffe\Documents\WindowsPowerShell\Modules
+PUBLIC = C:\Users\Public
+PublishableProject = 
+PublishBuildDependsOn = 
+            BuildOnlySettings;
+            PrepareForBuild;
+            ResolveReferences;
+            PrepareResources;
+            ResolveKeySource;
+            PrepareResourcesForSatelliteAssemblies;
+            GenerateSerializationAssemblies;
+            CreateSatelliteAssemblies;
+        
+PublishDependsOn = 
+      _DeploymentUnpublishable
+    
+PublishDir = bin\Release\app.publish\
+PublishOnlyDependsOn = 
+      SetGenerateManifests;
+      PublishBuild;
+      BeforePublish;
+      GenerateManifests;
+      CopyFilesToOutputDirectory;
+      CleanPublishFolder;
+      _CopyFilesToPublishFolder;
+      _DeploymentGenerateBootstrapper;
+      ResolveKeySource;
+      _DeploymentSignClickOnceDeployment;
+      AfterPublish
+    
+RebuildDependsOn = 
+      BeforeRebuild;
+      Clean;
+      Build;
+      AfterRebuild;
+    
+ReportingServicesTargets = C:\Program Files (x86)\MSBuild\Microsoft\VisualStudio\v11.0\ReportingServices\Microsoft.ReportingServices.targets
+ResGenDependsOn = ResolveAssemblyReferences;SplitResourcesByCulture;BeforeResGen;CoreResGen;AfterResGen
+ResGenExecuteAsTool = false
+ResolveAssemblyReferencesDependsOn = 
+      GetFrameworkPaths;
+      GetReferenceAssemblyPaths;
+      PrepareForBuild;
+      ResolveSDKReferences;
+      ExpandSDKReferences;
+    
+ResolveReferencesDependsOn = 
+      
+      BeforeResolveReferences;
+      AssignProjectConfiguration;
+      ResolveProjectReferences;
+      ResolveNativeReferences;
+      ResolveAssemblyReferences;
+      ResolveComReferences;
+      AfterResolveReferences
+    ;
+      ImplicitlyExpandDesignTimeFacades
+    
+ResolveSDKReferencesDependsOn = 
+      GetInstalledSDKLocations
+    
+RootNamespace = RustLanguageExtension
+RunAfterInstall = true
+RunDependsOn = 
+RunRegRichedDependsOn = ;FindSDKInstallation
+SatelliteDllsProjectOutputGroupDependsOn = PrepareForBuild;PrepareResourceNames
+SchemaVersion = 2.0
+SDK35ToolsPath = C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\bin\
+SDK40ToolsPath = 
+SDKRedistOutputGroupDependsOn = ResolveSDKReferences;ExpandSDKReferences
+SDKReferenceDirectoryRoot = C:\Users\dagriffe\AppData\Local\Microsoft SDKs;C:\Program Files (x86)\Microsoft SDKs
+SDKReferenceRegistryRoot = Software\Microsoft\Microsoft SDKs
+SESSIONNAME = Console
+SGenFilesOutputGroupDependsOn = 
+SGenShouldGenerateSerializer = true
+SGenUseProxyTypes = true
+ShouldCleanDeployedVsixExtensionFiles = true
+SignAssembly = true
+SkipCopyUnchangedFiles = true
+SolutionDir = *Undefined*
+SolutionExt = *Undefined*
+SolutionFileName = *Undefined*
+SolutionName = *Undefined*
+SolutionPath = *Undefined*
+SourceFilesProjectOutputGroupDependsOn = PrepareForBuild;AssignTargetPaths
+StartAction = Program
+StartArguments = /rootsuffix Exp
+StartupObject = 
+SubsystemVersion = 6.00
+SystemDrive = C:
+SystemRoot = C:\WINDOWS
+TargetCulture = *
+TargetDeployManifestFileName = RustLanguageExtension.application
+TargetDir = C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\bin\Release\
+TargetedFrameworkDir = @(_TargetedFrameworkDirectoryItem)
+TargetedRuntimeVersion = v4.0.30319
+TargetedSDKArchitecture = msil
+TargetedSDKConfiguration = Retail
+TargetExt = .dll
+TargetFileName = RustLanguageExtension.dll
+TargetFrameworkAsMSBuildRuntime = CurrentRuntime
+TargetFrameworkIdentifier = .NETFramework
+TargetFrameworkMoniker = .NETFramework,Version=v4.6.1
+TargetFrameworkMonikerAssemblyAttributesPath = C:\Users\dagriffe\AppData\Local\Temp\.NETFramework,Version=v4.6.1.AssemblyAttributes.cs
+TargetFrameworkSDKToolsDirectory = 
+TargetFrameworkVersion = v4.6.1
+TargetName = RustLanguageExtension
+TargetPath = C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\bin\Release\RustLanguageExtension.dll
+TargetPlatformIdentifier = Windows
+TargetPlatformMoniker = Windows,Version=7.0
+TargetPlatformRegistryBase = Software\Microsoft\Microsoft SDKs\Windows
+TargetPlatformSdkPath = 
+TargetPlatformVersion = 7.0
+TargetRuntime = Managed
+TargetVsixContainer = bin\Release\RustLanguageExtension.vsix
+TargetVsixContainerName = RustLanguageExtension.vsix
+TargetVSVersion = 15.0
+TaskKeyToken = 31bf3856ad364e35
+TaskVersion = 4.0.0.0
+TEMP = C:\Users\dagriffe\AppData\Local\Temp
+TemplateProjectOutputGroupDependsOn = 
+      ;
+      GetZipFilesFromVSTemplates;
+      CalculateZipFiles
+    
+ThisPackageDirectory = C:\Users\dagriffe\Documents\rls-vs2017\packages\Microsoft.VSSDK.BuildTools.15.5.100\build\..\
+TMP = C:\Users\dagriffe\AppData\Local\Temp
+ToastSettings = {"collection":[{"SolutionName":"Outlook Not Responding","SolutionStatus":true,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Outlook Multiple Process running","SolutionStatus":true,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Draft Email Protection","SolutionStatus":true,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Pending Reboot","SolutionStatus":false,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Password Reset","SolutionStatus":true,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"IE Recommended Settings","SolutionStatus":false,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Smart Card certificate is going to expire soon","SolutionStatus":false,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Smart Card has expired or multiple certificates","SolutionStatus":false,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Unable to connect to wireless LAN","SolutionStatus":true,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Wireless driver update","SolutionStatus":true,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Record Skype for Business experience","SolutionStatus":false,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Delete duplicate Outlook .ost file(s) to recover disk space","SolutionStatus":true,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"DirectAccess cannot connect","SolutionStatus":false,"ChangedBy":"Elevated tool. Ver:1.168.6.0"},{"SolutionName":"Outlook Multiple Processes running","SolutionStatus":true,"ChangedBy":"TM.Initialization"},{"SolutionName":"Direct Access cannot connect","SolutionStatus":false,"ChangedBy":"TM.Initialization"}]}
+UATDATA = C:\windows\CCM\UATData\D9F8C395-CAB8-491d-B8AC-179A1FE1BE77
+UnmanagedRegistrationDependsOn = 
+UnmanagedUnregistrationDependsOn = 
+UpgradeSubsetToProfile = true
+UseCodebase = true
+UseCommonOutputDirectory = false
+UseHostCompilerIfAvailable = true
+USERDNSDOMAIN = REDMOND.CORP.MICROSOFT.COM
+USERDOMAIN = REDMOND
+USERDOMAIN_ROAMINGPROFILE = REDMOND
+USERNAME = dagriffe
+USERPROFILE = C:\Users\dagriffe
+UseSourcePath = true
+Utf8Output = true
+ValidateVsixManifestDependsOn = ;FindSourceVsixManifest
+ValidateVsixPartsDependsOn = ;GetVsixSourceItems
+VerifyTargetVersion = true
+Version = 1.0.0.0
+VisualStudioVersion = 11.0
+VS140COMNTOOLS = C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\
+VSCTCompileDependsOn = ;FindSDKInstallation
+VsctVerboseOutput = false
+VsixCleanFile = RustLanguageExtension.csproj.VsixDeployedFileListAbsolute.txt
+VSIXIdentifierProjectOutputGroupDependsOn = ;FindSourceVsixManifest
+VsixManifestFileName = extension.vsixmanifest
+VSIXNameProjectOutputGroupDependsOn = ;FindSourceVsixManifest
+VSSDK140Install = C:\Program Files (x86)\Microsoft Visual Studio 14.0\VSSDK\
+VsSDKAssemblyFile = Microsoft.VisualStudio.Sdk.BuildTasks.15.0.dll
+VsSDKCommonAssemblyFile = Microsoft.VisualStudio.Sdk.BuildTasks.dll
+VsSDKIncludes = C:\Users\dagriffe\Documents\rls-vs2017\packages\Microsoft.VSSDK.BuildTools.15.5.100\build\..\\tools\VSSDK\inc
+VsSDKInstall = C:\Users\dagriffe\Documents\rls-vs2017\packages\Microsoft.VSSDK.BuildTools.15.5.100\build\..\\tools\VSSDK
+VSSDKTargetPlatformRegRoot = Software\Microsoft\VisualStudio\15.0
+VSSDKTargetPlatformRegRootSuffix = Exp
+VSSDKTargetPlatformVersion = 15.0
+VSSDKTargetsPath = C:\Program Files (x86)\MSBuild\Microsoft\VisualStudio\v15.0\VSSDK
+VsSDKToolsPath = C:\Users\dagriffe\Documents\rls-vs2017\packages\Microsoft.VSSDK.BuildTools.15.5.100\build\..\\tools\VSSDK\bin
+VsSDKVersion = 15.0
+VSToolsPath = C:\Users\dagriffe\Documents\rls-vs2017\packages\Microsoft.VSSDK.BuildTools.15.5.100\build\..\\tools
+WarningLevel = 4
+WebReference_EnableLegacyEventingModel = false
+WebReference_EnableProperties = true
+WebReference_EnableSQLTypes = true
+windir = C:\WINDOWS
+WindowsSDK80Path = 
+WorkflowBuildExtensionAssemblyName = Microsoft.Activities.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
+WorkflowBuildExtensionKeyToken = 31bf3856ad364e35
+WorkflowBuildExtensionVersion = 4.0.0.0
+XamlBuildTaskAssemblyName = XamlBuildTask, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
+XamlBuildTaskLocation = C:\Windows\Microsoft.NET\Framework\v4.0.30319
+XamlGenCodeFileNames = RustLanguageExtension.csproj.XamlGeneratedCodeFileListAbsolute.txt
+XamlGenMarkupFileNames = RustLanguageExtension.csproj.XamlGeneratedXamlFileListAbsolute.txt
+XamlPass2FlagFile = RustLanguageExtension.csproj.XamlPass2Flag.txt
+XamlRequiresCompilationPass2 = false
+XamlTemporaryAssemblyName = RustLanguageExtension
+YieldDuringToolExecution = true
+ZipFilesDependsOn = GetZipFilesFromVSTemplates;CalculateZipFiles
+ZipIntermediatePath = obj\Release\
+ZipItemOutput = bin\Release\
+ZipPackageCompressionLevel = normal
+ZipProjectOutput = bin\Release\
+
+Initial Items:
+_ApplicationManifestFinal
+    bin\Release\Native.RustLanguageExtension.manifest
+        TargetPath = Native.RustLanguageExtension.manifest
+_DebugSymbolsIntermediatePath
+    obj\Release\RustLanguageExtension.pdb
+_DebugSymbolsOutputPath
+    bin\Release\RustLanguageExtension.pdb
+_DeploymentManifestEntryPoint
+    obj\Release\RustLanguageExtension.dll
+        TargetPath = RustLanguageExtension.dll
+_ExplicitReference
+    C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.1\mscorlib.dll
+_OutputPathItem
+    bin\Release\
+_ResolveComReferenceCache
+    obj\Release\RustLanguageExtension.csproj.ResolveComReference.cache
+_UnmanagedRegistrationCache
+    obj\RustLanguageExtension.csproj.UnmanagedRegistration.cache
+AppConfigFileDestination
+    bin\Release\RustLanguageExtension.dll.config
+ApplicationManifest
+    obj\Release\Native.RustLanguageExtension.manifest
+        TargetPath = Native.RustLanguageExtension.manifest
+AvailableItemName
+    EntityDeploy
+    VSTemplate
+    ZipItem
+    ZipProject
+BuiltProjectOutputGroupKeyOutput
+    C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\obj\Release\RustLanguageExtension.dll
+        IsKeyOutput = true
+        FinalOutputPath = C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\bin\Release\RustLanguageExtension.dll
+        TargetPath = RustLanguageExtension.dll
+Compile
+    OptionsModel.cs
+    OptionsPage.cs
+        SubType = Component
+    Properties\AssemblyInfo.cs
+    RustContentDefinition.cs
+    RustLanguageExtension.cs
+    RustLanguageExtensionOptionsPackage.cs
+    Rustup.cs
+    Utilities.cs
+    VsUtilities.cs
+DebugSymbolsProjectOutputGroupOutput
+    C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\obj\Release\RustLanguageExtension.pdb
+        FinalOutputPath = C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\bin\Release\RustLanguageExtension.pdb
+        TargetPath = RustLanguageExtension.pdb
+DeployManifest
+    obj\Release\RustLanguageExtension.application
+        TargetPath = RustLanguageExtension.application
+EmbeddedResource
+    VSPackage.resx
+        MergeWithCTO = true
+        ManifestResourceName = VSPackage
+        SubType = Designer
+IntermediateAssembly
+    obj\Release\RustLanguageExtension.dll
+None
+    app.config
+        SubType = Designer
+    Key.snk
+    packages.config
+    source.extension.vsixmanifest
+        SubType = Designer
+Reference
+    EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+        EmbedInteropTypes = False
+    EnvDTE100, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        EmbedInteropTypes = False
+    EnvDTE80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+        EmbedInteropTypes = False
+    EnvDTE90, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+        EmbedInteropTypes = False
+    Microsoft.CSharp
+    Microsoft.VisualStudio.CommandBars, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+        EmbedInteropTypes = False
+    Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        HintPath = ..\packages\Microsoft.VisualStudio.CoreUtility.15.4.27004\lib\net45\Microsoft.VisualStudio.CoreUtility.dll
+        Private = True
+    Microsoft.VisualStudio.ImageCatalog, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        HintPath = ..\packages\Microsoft.VisualStudio.ImageCatalog.15.4.27004\lib\net45\Microsoft.VisualStudio.ImageCatalog.dll
+        Private = True
+    Microsoft.VisualStudio.Imaging, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        HintPath = ..\packages\Microsoft.VisualStudio.Imaging.15.4.27004\lib\net45\Microsoft.VisualStudio.Imaging.dll
+        Private = True
+    Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        EmbedInteropTypes = True
+        HintPath = ..\packages\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.14.3.25407\lib\Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime.dll
+        Private = True
+    Microsoft.VisualStudio.LanguageServer.Client.Preview, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        HintPath = ..\packages\Microsoft.VisualStudio.LanguageServer.Client.1.0.60-pre\lib\net461\Microsoft.VisualStudio.LanguageServer.Client.Preview.dll
+    Microsoft.VisualStudio.LanguageServer.Protocol.Preview, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        HintPath = ..\packages\Microsoft.VisualStudio.LanguageServer.Protocol.1.0.60-pre\lib\net461\Microsoft.VisualStudio.LanguageServer.Protocol.Preview.dll
+    Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+        HintPath = ..\packages\Microsoft.VisualStudio.OLE.Interop.7.10.6070\lib\Microsoft.VisualStudio.OLE.Interop.dll
+        Private = True
+    Microsoft.VisualStudio.Shell.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        HintPath = ..\packages\Microsoft.VisualStudio.Shell.15.0.15.4.27004\lib\Microsoft.VisualStudio.Shell.15.0.dll
+        Private = True
+    Microsoft.VisualStudio.Shell.Framework, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        HintPath = ..\packages\Microsoft.VisualStudio.Shell.Framework.15.4.27004\lib\net45\Microsoft.VisualStudio.Shell.Framework.dll
+        Private = True
+    Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+        HintPath = ..\packages\Microsoft.VisualStudio.Shell.Interop.7.10.6071\lib\Microsoft.VisualStudio.Shell.Interop.dll
+        Private = True
+    Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        EmbedInteropTypes = True
+        HintPath = ..\packages\Microsoft.VisualStudio.Shell.Interop.10.0.10.0.30319\lib\Microsoft.VisualStudio.Shell.Interop.10.0.dll
+        Private = True
+    Microsoft.VisualStudio.Shell.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        EmbedInteropTypes = True
+        HintPath = ..\packages\Microsoft.VisualStudio.Shell.Interop.11.0.11.0.61030\lib\Microsoft.VisualStudio.Shell.Interop.11.0.dll
+        Private = True
+    Microsoft.VisualStudio.Shell.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        EmbedInteropTypes = True
+        HintPath = ..\packages\Microsoft.VisualStudio.Shell.Interop.12.0.12.0.30110\lib\Microsoft.VisualStudio.Shell.Interop.12.0.dll
+        Private = True
+    Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        EmbedInteropTypes = True
+        HintPath = ..\packages\Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.14.3.25407\lib\Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime.dll
+        Private = True
+    Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        EmbedInteropTypes = True
+        HintPath = ..\packages\Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime.15.0.26606\lib\net20\Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime.dll
+        Private = True
+    Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+        HintPath = ..\packages\Microsoft.VisualStudio.Shell.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.Shell.Interop.8.0.dll
+        Private = True
+    Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+        HintPath = ..\packages\Microsoft.VisualStudio.Shell.Interop.9.0.9.0.30729\lib\Microsoft.VisualStudio.Shell.Interop.9.0.dll
+        Private = True
+    Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+        HintPath = ..\packages\Microsoft.VisualStudio.TextManager.Interop.7.10.6070\lib\Microsoft.VisualStudio.TextManager.Interop.dll
+        Private = True
+    Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+        HintPath = ..\packages\Microsoft.VisualStudio.TextManager.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.TextManager.Interop.8.0.dll
+        Private = True
+    Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        HintPath = ..\packages\Microsoft.VisualStudio.Threading.15.4.4\lib\net45\Microsoft.VisualStudio.Threading.dll
+    Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        HintPath = ..\packages\Microsoft.VisualStudio.Utilities.15.4.27004\lib\net46\Microsoft.VisualStudio.Utilities.dll
+        Private = True
+    Microsoft.VisualStudio.Validation, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        HintPath = ..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll
+        Private = True
+    Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL
+        HintPath = ..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll
+        Private = True
+    stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+        EmbedInteropTypes = False
+    StreamJsonRpc, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL
+        HintPath = ..\packages\StreamJsonRpc.1.2.8\lib\net45\StreamJsonRpc.dll
+    System
+    System.ComponentModel.Composition
+    System.Data
+    System.Design
+    System.Drawing
+    System.Net.Http
+    System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL
+        HintPath = ..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll
+        Private = False
+    System.Windows.Forms
+    System.Xml
+XamlBuildTaskTypeGenerationExtensionName
+    Microsoft.Activities.Build.BeforeInitializeComponentExtension
+        AssemblyName = Microsoft.Activities.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
+        Visible = false
+    Microsoft.Activities.Build.Debugger.DebugBuildExtension
+        AssemblyName = Microsoft.Activities.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
+        Visible = false
+
+Building with tools version "15.0".
+Project file contains ToolsVersion="15.0". This toolset may be unknown or missing, in which case you may be able to resolve this by installing the appropriate version of MSBuild, or the build may have been forced to a particular ToolsVersion for policy reasons. Treating the project as if it had ToolsVersion="4.0". For more information, please see http://go.microsoft.com/fwlink/?LinkId=291333.
+Target "_CheckForInvalidConfigurationAndPlatform: (TargetId:2)" in file "C:\Windows\Microsoft.NET\Framework\v4.0.30319\Microsoft.Common.targets" from project "C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\RustLanguageExtension.csproj" (entry point):
+Task "Error" skipped, due to false condition; ( '$(_InvalidConfigurationError)' == 'true' ) was evaluated as ( '' == 'true' ).
+Task "Warning" skipped, due to false condition; ( '$(_InvalidConfigurationWarning)' == 'true' ) was evaluated as ( '' == 'true' ).
+Using "Message" task from assembly "Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
+Task "Message" (TaskId:2)
+  Task Parameter:Text=Configuration=Release (TaskId:2)
+  Task Parameter:Importance=Low (TaskId:2)
+  Configuration=Release (TaskId:2)
+Done executing task "Message". (TaskId:2)
+Task "Message" (TaskId:3)
+  Task Parameter:Text=Platform=AnyCPU (TaskId:3)
+  Task Parameter:Importance=Low (TaskId:3)
+  Platform=AnyCPU (TaskId:3)
+Done executing task "Message". (TaskId:3)
+Task "Error" skipped, due to false condition; ('$(OutDir)' != '' and !HasTrailingSlash('$(OutDir)')) was evaluated as ('bin\Release\' != '' and !HasTrailingSlash('bin\Release\')).
+Task "Error" skipped, due to false condition; ('$(BaseIntermediateOutputPath)' != '' and !HasTrailingSlash('$(BaseIntermediateOutputPath)')) was evaluated as ('obj\' != '' and !HasTrailingSlash('obj\')).
+Task "Error" skipped, due to false condition; ('$(IntermediateOutputPath)' != '' and !HasTrailingSlash('$(IntermediateOutputPath)')) was evaluated as ('obj\Release\' != '' and !HasTrailingSlash('obj\Release\')).
+Done building target "_CheckForInvalidConfigurationAndPlatform" in project "RustLanguageExtension.csproj".: (TargetId:2)
+Target "VerifyTargetVersion: (TargetId:3)" in file "C:\Users\dagriffe\Documents\rls-vs2017\packages\Microsoft.VSSDK.BuildTools.15.5.100\tools\VSSDK\Microsoft.VsSDK.targets" from project "C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\RustLanguageExtension.csproj" (target "Build" depends on it):
+Using "CompareCommonBuildTaskVersion" task from assembly "C:\Users\dagriffe\Documents\rls-vs2017\packages\Microsoft.VSSDK.BuildTools.15.5.100\tools\VSSDK\Microsoft.VisualStudio.Sdk.BuildTasks.dll".
+Task "CompareCommonBuildTaskVersion" (TaskId:4)
+  Task Parameter:TargetsAssemblyPath=C:\Users\dagriffe\Documents\rls-vs2017\packages\Microsoft.VSSDK.BuildTools.15.5.100\tools\VSSDK\Microsoft.VisualStudio.Sdk.BuildTasks.dll (TaskId:4)
+Done executing task "CompareCommonBuildTaskVersion". (TaskId:4)
+C:\Users\dagriffe\Documents\rls-vs2017\packages\Microsoft.VSSDK.BuildTools.15.5.100\tools\VSSDK\Microsoft.VsSDK.targets(86,5): error MSB4062: The "CompareBuildTaskVersion" task could not be loaded from the assembly C:\Users\dagriffe\Documents\rls-vs2017\packages\Microsoft.VSSDK.BuildTools.15.5.100\tools\VSSDK\Microsoft.VisualStudio.Sdk.BuildTasks.15.0.dll. Could not load file or assembly 'Microsoft.Build.Utilities.Core, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified. Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask. [C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\RustLanguageExtension.csproj]
+Done building target "VerifyTargetVersion" in project "RustLanguageExtension.csproj" -- FAILED.: (TargetId:3)
+Done Building Project "C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\RustLanguageExtension.csproj" (default targets) -- FAILED.
+Deferred Messages
+
+Detailed Build Summary
+======================
+     (TaskId:0)
+  
+  ============================== Build Hierarchy (IDs represent configurations) =====================================================
+  Id                  : Exclusive Time   Total Time   Path (Targets)
+  ----------------------------------------------------------------------------------------------------------------------------------- (TaskId:0)
+  0                   : 0.404s           0.404s       C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\RustLanguageExtension.csproj ()  (TaskId:0)
+  
+  ============================== Node Utilization (IDs represent configurations) ====================================================
+  Timestamp:            1        Duration   Cumulative
+  ----------------------------------------------------------------------------------------------------------------------------------- (TaskId:0)
+  636483714492257662:   0        0.408s     0.408s ######## (TaskId:0)
+  -----------------------------------------------------------------------------------------------------------------------------------
+  Utilization:          100.0    Average Utilization: 100.0 (TaskId:0)
+
+Project Performance Summary:
+      195 ms  C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\RustLanguageExtension.csproj   1 calls
+
+Target Performance Summary:
+       48 ms  VerifyTargetVersion                        1 calls
+       78 ms  _CheckForInvalidConfigurationAndPlatform   1 calls
+
+Task Performance Summary:
+        4 ms  CompareCommonBuildTaskVersion              1 calls
+       27 ms  Message                                    2 calls
+
+Build FAILED.
+
+"C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\RustLanguageExtension.csproj" (default target) (1) ->
+(VerifyTargetVersion target) -> 
+  C:\Users\dagriffe\Documents\rls-vs2017\packages\Microsoft.VSSDK.BuildTools.15.5.100\tools\VSSDK\Microsoft.VsSDK.targets(86,5): error MSB4062: The "CompareBuildTaskVersion" task could not be loaded from the assembly C:\Users\dagriffe\Documents\rls-vs2017\packages\Microsoft.VSSDK.BuildTools.15.5.100\tools\VSSDK\Microsoft.VisualStudio.Sdk.BuildTasks.15.0.dll. Could not load file or assembly 'Microsoft.Build.Utilities.Core, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified. Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask. [C:\Users\dagriffe\Documents\rls-vs2017\RustLanguageExtension\RustLanguageExtension.csproj]
+
+    0 Warning(s)
+    1 Error(s)
+
+Time Elapsed 00:00:00.49


### PR DESCRIPTION
AppVeyor uses an older version of VS2017 with a bug that overrides some settings sets by `Microsoft.VSSDK.BuildTools.props` during the build. Moving the `Microsoft.Common.props` file to before `Microsoft.VSSDK.BuildTools.props` works around the issue.