### PR TITLE
VS2017 15.9.12 Fixes

### DIFF
--- a/src/RustLanguageExtension/Properties/launchSettings.json
+++ b/src/RustLanguageExtension/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "RustLanguageExtension": {
+      "commandName": "Executable",
+      "executablePath": "$(DevEnvDir)\\devenv.exe",
+      "commandLineArgs": "/rootsuffix Exp"
+    }
+  }
+}

--- a/src/RustLanguageExtension/RustLanguageExtension.csproj
+++ b/src/RustLanguageExtension/RustLanguageExtension.csproj
@@ -20,7 +20,7 @@
     <StartAction>Program</StartAction>
     <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>
-    <RegisterWithCodebase>true</RegisterWithCodebase>
+    <UseCodebase>true</UseCodebase>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RustLanguageExtension/RustLanguageExtension.csproj
+++ b/src/RustLanguageExtension/RustLanguageExtension.csproj
@@ -20,6 +20,7 @@
     <StartAction>Program</StartAction>
     <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>
+    <RegisterWithCodebase>true</RegisterWithCodebase>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Couple of minor fixes for the following issues:
* VS2017 appears to be ignoring the .csproj settings to allow debugging the vsix.
* VS2017 has trouble loading the extension assembly for the Tools > Options > Rust menu.